### PR TITLE
Add support for boolean and optional parameters

### DIFF
--- a/mwapi/session.py
+++ b/mwapi/session.py
@@ -345,6 +345,8 @@ class Session:
 def _normalize_value(value):
     if isinstance(value, str):
         return value
+    elif isinstance(value, bool):
+        return "" if value else None
     elif hasattr(value, "__iter__"):
         return "|".join(str(v) for v in value)
     else:
@@ -353,6 +355,7 @@ def _normalize_value(value):
 
 def _normalize_params(params, query_continue=None):
     normal_params = {k: _normalize_value(v) for k, v in params.items()}
+    normal_params = {k: v for k, v in normal_params.items() if v is not None}
 
     if query_continue is not None:
         normal_params.update(query_continue)


### PR DESCRIPTION
`True` parameters are turned into the empty string, and `False` and `None` parameters are completely removed from the params dict. Fixes #37.