### PR TITLE
Add optional HTTP origin parameter to Session.

### DIFF
--- a/mwapi/session.py
+++ b/mwapi/session.py
@@ -35,7 +35,7 @@ class Session:
     :Parameters:
         host : `str`
             Host to which to connect to. Must include http:// or https:// and
-            no trailing "/".
+            no trailing "/", unless "origin" is also specified.
         user_agent : `str`
             The User-Agent header to include with all requests.  Use this field
             to identify your script/bot/application to system admins of the
@@ -52,16 +52,25 @@ class Session:
             is to hang indefinitely.
         session : `requests.Session`
             (optional) a `requests` session object to use
+        origin: `str`
+            An alternate host to query instead of the host that corresponds
+            to the literal value of the "host" parameter. Useful for interacting
+            with load balancers and internal hostnames.
     """
 
     def __init__(self, host, user_agent=None, formatversion=None,
                  api_path=None,
-                 timeout=None, session=None, **session_params):
+                 timeout=None, session=None, origin=None,
+                 **session_params):
         self.host = str(host)
         self.formatversion = int(formatversion) \
             if formatversion is not None else None
         self.api_path = str(api_path or "/w/api.php")
-        self.api_url = self.host + self.api_path
+        if origin:
+            self.api_url = origin + self.api_path
+        else:
+            self.api_url = self.host + self.api_path
+
         self.timeout = float(timeout) if timeout is not None else None
         self.session = session or requests.Session()
         for key, value in session_params.items():
@@ -76,6 +85,9 @@ class Session:
             self.headers['User-Agent'] = DEFAULT_USERAGENT
         else:
             self.headers['User-Agent'] = user_agent
+
+        if origin:
+            self.headers['Host'] = self.host
 
     def _request(self, method, params=None, files=None, auth=None):
         params = params or {}


### PR DESCRIPTION
Interally within WMF we do not access the API servers via external
hostnames, but we need to access the APIs for a given wiki via our
internal appserver endpoint. Currently this is not possible as using
the appserver hostname directly doesn't set a valid Host header for a
wiki. This change adds an `origin` parameter to the Session object
which allows the host to be used as the HTTP Host header while
connecting to the IP or hostname of the given `origin`.