### PR TITLE
Support async session via aiohttp

### DIFF
--- a/mwapi/__init__.py
+++ b/mwapi/__init__.py
@@ -13,12 +13,13 @@ convenience functions for calling the MediaWiki API -- for example,
 :License: MIT
 """
 from .session import Session
+from .async_session import AsyncSession
 from .about import (__name__, __version__, __author__, __author_email__,
                     __description__, __license__, __url__)
 
 
 MWApi = Session
 
-__all__ = [MWApi, Session,
+__all__ = [MWApi, Session, AsyncSession,
            __name__, __version__, __author__, __author_email__,
            __description__, __license__, __url__]

--- a/mwapi/async_session.py
+++ b/mwapi/async_session.py
@@ -1,0 +1,213 @@
+import logging
+
+import asyncio
+import aiohttp
+
+from .errors import (APIError, ConnectionError, RequestError, TimeoutError,
+                     TooManyRedirectsError)
+from .util import _normalize_params
+
+DEFAULT_USERAGENT = "mwapi (python) -- default user-agent"
+
+logger = logging.getLogger(__name__)
+
+
+class AsyncSession:
+    """
+    Constructs a new API asynchronous session.
+
+    :Parameters:
+        host : `str`
+            Host to which to connect to. Must include http:// or https:// and
+            no trailing "/".
+        user_agent : `str`
+            The User-Agent header to include with all requests.  Use this field
+            to identify your script/bot/application to system admins of the
+            MediaWiki API you are using.
+        formatversion : int
+            The formatversion to supply to the API for all requests.
+        api_path : `str`
+            The path to "api.php" on the server -- must begin with "/".
+        timeout : `float`
+            How long to wait for the server to send data before giving up
+            and raising an error (
+            :class:`aiohttp.client_exceptions.ServerTimeoutError` or
+            :class:`asyncio.exceptions.TimeoutError`).
+            By default aiohttp uses a total 300 seconds (5min) timeout.
+        session : `aiohttp.ClientSession`
+            (optional) an `aiohttp` session object to use
+    """
+
+    def __init__(self, host, user_agent=None, formatversion=None,
+                 api_path=None,
+                 timeout=None, session=None, **session_params):
+        self.host = str(host)
+        self.formatversion = int(formatversion) \
+            if formatversion is not None else None
+        self.api_path = str(api_path or "/w/api.php")
+        self.api_url = self.host + self.api_path
+        self.timeout = float(timeout) \
+            if timeout is not None else aiohttp.ClientTimeout(total=300)
+        self.session = session or aiohttp.ClientSession()
+        for key, value in session_params.items():
+            setattr(self.session, key, value)
+
+        self.headers = {}
+
+        if user_agent is None:
+            logger.warning("Sending requests with default User-Agent.  " +
+                           "Set 'user_agent' on mwapi.Session to quiet this " +
+                           "message.")
+            self.headers['User-Agent'] = DEFAULT_USERAGENT
+        else:
+            self.headers['User-Agent'] = user_agent
+
+    async def _request(self, method, params=None, auth=None):
+        params = params or {}
+        if self.formatversion is not None:
+            params['formatversion'] = self.formatversion
+
+        if method.lower() == "post":
+            data = params
+            data['format'] = "json"
+            params = None
+
+        else:
+            data = None
+            params = params or {}
+            params['format'] = "json"
+
+        try:
+            async with self.session.request(method=method, url=self.api_url,
+                                            params=params, data=data,
+                                            timeout=self.timeout,
+                                            headers=self.headers,
+                                            verify_ssl=True,
+                                            auth=auth) as resp:
+
+                doc = await resp.json()
+
+                if 'error' in doc:
+                    raise APIError.from_doc(doc['error'])
+
+                if 'warnings' in doc:
+                    logger.warning("The following query raised warnings: {0}"
+                                   .format(params or data))
+                    for module, warning in doc['warnings'].items():
+                        logger.warning("\t- {0} -- {1}"
+                                       .format(module, warning))
+                return doc
+
+        except (ValueError, aiohttp.ContentTypeError):
+            if resp is None:
+                prefix = "No response data"
+            else:
+                prefix = (await resp.text())[:350]
+            raise ValueError("Could not decode as JSON:\n{0}"
+                             .format(prefix))
+        except (aiohttp.ServerTimeoutError,
+                asyncio.exceptions.TimeoutError) as e:
+            raise TimeoutError(str(e)) from e
+        except aiohttp.ClientConnectionError as e:
+            raise ConnectionError(str(e)) from e
+        except aiohttp.TooManyRedirects as e:
+            raise TooManyRedirectsError(str(e)) from e
+        except Exception as e:
+            raise RequestError(str(e)) from e
+
+
+    async def request(self, method, params=None, query_continue=None,
+                      auth=None, continuation=False):
+        """
+        Sends an HTTP request to the API.
+
+        :Parameters:
+            method : `str`
+                Which HTTP method to use for the request?
+                (Usually "POST" or "GET")
+            params : `dict`
+                A set of parameters to send with the request.  These parameters
+                will be included in the POST body for post requests or a query
+                string otherwise.
+            query_continue : `dict`
+                A 'continue' field from a past request.  This field represents
+                the point from which a query should be continued.
+            auth : mixed
+                Auth tuple or callable to enable Basic/Digest/Custom HTTP Auth.
+            continuation : `bool`
+                If true, a continuation will be attempted and a generator of
+                JSON response documents will be returned.
+
+        :Returns:
+            A response JSON documents (or a generator of documents if
+            `continuation == True`)
+        """
+        normal_params = _normalize_params(params, query_continue)
+        if continuation:
+            return self._continuation(method, params=normal_params, auth=auth)
+        else:
+            return await self._request(method, params=normal_params, auth=auth)
+
+    async def _continuation(self, method, params=None, auth=None):
+        if "continue" not in params:
+            params["continue"] = ""
+
+        while True:
+            doc = await self._request(method, params=params, auth=auth)
+            yield doc
+            if "continue" not in doc:
+                break
+            # re-send all continue values in the next call
+            params.update(doc["continue"])
+
+    async def get(self, query_continue=None, auth=None, continuation=False,
+                  **params):
+        """Makes an API request with the GET method
+
+        :Parameters:
+            query_continue : `dict`
+                Optionally, the value of a query continuation 'continue' field.
+            auth : mixed
+                Auth tuple or callable to enable Basic/Digest/Custom HTTP Auth.
+            continuation : `bool`
+                If true, a continuation will be attempted and a generator of
+                JSON response documents will be returned.
+            params :
+                Keyword parameters to be sent in the query string.
+
+        :Returns:
+            A response JSON documents (or a generator of documents if
+            `continuation == True`)
+
+        :Raises:
+            :class:`mwapi.errors.APIError` : if the API responds with an error
+        """
+        return await self.request("GET", params=params, auth=auth,
+                                  query_continue=query_continue,
+                                  continuation=continuation)
+
+    async def post(self, query_continue=None, auth=None, continuation=False,
+                   **params):
+        """Makes an API request with the POST method
+
+        :Parameters:
+            query_continue : `dict`
+                Optionally, the value of a query continuation 'continue' field.
+            auth : mixed
+                Auth tuple or callable to enable Basic/Digest/Custom HTTP Auth.
+            continuation : `bool`
+                If true, a continuation will be attempted and a generator of
+                JSON response documents will be returned.
+            params :
+                Keyword parameters to be sent in the POST message body.
+
+        :Returns:
+            A response JSON documents (or a generator of documents if
+            `continuation == True`)
+
+        :Raises:
+            :class:`mwapi.errors.APIError` : if the API responds with an error
+        """
+        return await self.request("POST", params=params, auth=auth,
+                                  query_continue=query_continue,
+                                  continuation=continuation)

--- a/mwapi/errors.py
+++ b/mwapi/errors.py
@@ -17,6 +17,8 @@ Errors
 .. autoclass:: TimeoutError
 """
 import requests.exceptions
+import aiohttp
+import asyncio
 
 
 class APIError(RuntimeError):
@@ -66,16 +68,19 @@ class ClientInteractionRequest(RuntimeError):
         return cls(login_token, doc.get('message'), doc.get('requests', []))
 
 
-class RequestError(requests.exceptions.RequestException):
+class RequestError(requests.exceptions.RequestException,
+                   aiohttp.ClientError):
     """
-    A generic error thrown by :mod:`requests`.
+    A generic error thrown by :mod:`requests` or `aiohttp`.
     """
     pass
 
 
-class ConnectionError(requests.exceptions.ConnectionError):
+class ConnectionError(requests.exceptions.ConnectionError,
+                      aiohttp.ClientConnectionError):
     """
-    Handles a :class:`requests.exceptions.ConnectionError`
+    Handles a :class:`requests.exceptions.ConnectionError` or
+              :class:`aiohttp.ClientConnectionError`.
     """
     pass
 
@@ -87,15 +92,21 @@ class HTTPError(requests.exceptions.HTTPError):
     pass
 
 
-class TooManyRedirectsError(requests.exceptions.TooManyRedirects):
+class TooManyRedirectsError(requests.exceptions.TooManyRedirects,
+                            aiohttp.TooManyRedirects):
     """
-    Handles a :class:`requests.exceptions.TooManyRedirects`
+    Handles a :class:`requests.exceptions.TooManyRedirects` or
+              :class:`aiohttp.TooManyRedirects`.
     """
     pass
 
 
-class TimeoutError(requests.exceptions.Timeout):
+class TimeoutError(requests.exceptions.Timeout,
+                   aiohttp.ServerTimeoutError,
+                   asyncio.exceptions.TimeoutError):
     """
-    Handles a :class:`requests.exceptions.TimeoutError`
+    Handles a :class:`requests.exceptions.TimeoutError` or
+              :class:`aiohttp.ServerTimeoutError` or
+              :class:`asyncio.exceptions.TimeoutError`.
     """
     pass

--- a/mwapi/session.py
+++ b/mwapi/session.py
@@ -22,6 +22,7 @@ import requests.exceptions
 from .errors import (APIError, ClientInteractionRequest, ConnectionError,
                      HTTPError, LoginError, RequestError, TimeoutError,
                      TooManyRedirectsError)
+from .util import _normalize_params
 
 DEFAULT_USERAGENT = "mwapi (python) -- default user-agent"
 
@@ -340,24 +341,3 @@ class Session:
         return self.request('POST', params=params, auth=auth,
                             query_continue=query_continue, files=files,
                             continuation=continuation)
-
-
-def _normalize_value(value):
-    if isinstance(value, str):
-        return value
-    elif isinstance(value, bool):
-        return "" if value else None
-    elif hasattr(value, "__iter__"):
-        return "|".join(str(v) for v in value)
-    else:
-        return value
-
-
-def _normalize_params(params, query_continue=None):
-    normal_params = {k: _normalize_value(v) for k, v in params.items()}
-    normal_params = {k: v for k, v in normal_params.items() if v is not None}
-
-    if query_continue is not None:
-        normal_params.update(query_continue)
-
-    return normal_params

--- a/mwapi/util.py
+++ b/mwapi/util.py
@@ -1,0 +1,19 @@
+def _normalize_value(value):
+    if isinstance(value, str):
+        return value
+    elif isinstance(value, bool):
+        return "" if value else None
+    elif hasattr(value, "__iter__"):
+        return "|".join(str(v) for v in value)
+    else:
+        return value
+
+
+def _normalize_params(params, query_continue=None):
+    normal_params = {k: _normalize_value(v) for k, v in params.items()}
+    normal_params = {k: v for k, v in normal_params.items() if v is not None}
+
+    if query_continue is not None:
+        normal_params.update(query_continue)
+
+    return normal_params

--- a/setup.py
+++ b/setup.py
@@ -15,5 +15,5 @@ setup(
     license=__license__,  # noqa
     packages=["mwapi"],
     long_description=open("README.md").read(),
-    install_requires=["requests"]
+    install_requires=["requests", "aiohttp"]
 )


### PR DESCRIPTION
`mwapi` lacks support for asynchronous frameworks. At WMF ML team, we're building the Lift Wing platform based on kserve for serving the machine learning models. However, we encounter high latency when calling the mwapi in kserve with blocking codes.

We would like to add support for asynchronous functionality in mwapi using the async/await syntax and the asynchronous HTTP client/server [aiohttp](https://docs.aiohttp.org/en/stable/).

Bug: T313493