### PR TITLE
Change 'asyncio.exceptions.TimeoutError' to 'asyncio.TimeoutError'

### DIFF
--- a/mwapi/async_session.py
+++ b/mwapi/async_session.py
@@ -32,7 +32,7 @@ class AsyncSession:
             How long to wait for the server to send data before giving up
             and raising an error (
             :class:`aiohttp.client_exceptions.ServerTimeoutError` or
-            :class:`asyncio.exceptions.TimeoutError`).
+            :class:`asyncio.TimeoutError`).
             By default aiohttp uses a total 300 seconds (5min) timeout.
         session : `aiohttp.ClientSession`
             (optional) an `aiohttp` session object to use
@@ -106,7 +106,7 @@ class AsyncSession:
             raise ValueError("Could not decode as JSON:\n{0}"
                              .format(prefix))
         except (aiohttp.ServerTimeoutError,
-                asyncio.exceptions.TimeoutError) as e:
+                asyncio.TimeoutError) as e:
             raise TimeoutError(str(e)) from e
         except aiohttp.ClientConnectionError as e:
             raise ConnectionError(str(e)) from e

--- a/mwapi/errors.py
+++ b/mwapi/errors.py
@@ -103,10 +103,10 @@ class TooManyRedirectsError(requests.exceptions.TooManyRedirects,
 
 class TimeoutError(requests.exceptions.Timeout,
                    aiohttp.ServerTimeoutError,
-                   asyncio.exceptions.TimeoutError):
+                   asyncio.TimeoutError):
     """
     Handles a :class:`requests.exceptions.TimeoutError` or
               :class:`aiohttp.ServerTimeoutError` or
-              :class:`asyncio.exceptions.TimeoutError`.
+              :class:`asyncio.TimeoutError`.
     """
     pass


### PR DESCRIPTION
In Python 3.7, 'asyncio.exceptions.TimeoutError' raises AttributeError:
 module 'asyncio' has no attribute 'exceptions', since it's in class
 'concurrent.futures._base.TimeoutError'. In Python 3.8 onward,
 TimeoutError is in class 'asyncio.exceptions.TimeoutError'. Written as
 'asyncio.TimeoutError' will be acceptable for either version.

Bug: T313493