### PR TITLE
async_session.py: check the HTTP response code

### DIFF
--- a/mwapi/async_session.py
+++ b/mwapi/async_session.py
@@ -84,8 +84,11 @@ class AsyncSession:
                                             headers=self.headers,
                                             verify_ssl=True,
                                             auth=auth) as resp:
-
-                doc = await resp.json()
+                if resp.status < 500:
+                    doc = await resp.json()
+                else:
+                    raise APIError(
+                        resp.status, "50x HTTP response", resp.reason)
 
                 if 'error' in doc:
                     raise APIError.from_doc(doc['error'])


### PR DESCRIPTION
In case a HTTP 50x is returned, we shouldn't try to transform the payload of the response to JSON to avoid any ValueError exception like the following:

ValueError: Could not decode as JSON

Bug: T322196